### PR TITLE
feat: work for auditing

### DIFF
--- a/source/did-issuer-server/build.gradle
+++ b/source/did-issuer-server/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
     implementation 'org.apache.commons:commons-pool2:2.12.0'
     implementation('org.hyperledger.fabric:fabric-gateway-java:2.2.9')
+    testRuntimeOnly 'com.h2database:h2'
     implementation fileTree(dir: "libs", includes: ["*"])
 
 }

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/config/JpaConfig.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package org.omnione.did.base.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/BaseEntity.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/BaseEntity.java
@@ -19,7 +19,6 @@ package org.omnione.did.base.db.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
@@ -33,10 +32,10 @@ import java.time.Instant;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
-    @NotNull
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt = Instant.now();
+    private Instant createdAt;
 
     @LastModifiedDate
     @Column(name = "updated_at", insertable = false)

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/CertificateVc.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/CertificateVc.java
@@ -18,12 +18,7 @@ package org.omnione.did.base.db.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.io.Serializable;
-import java.time.Instant;
 
 /**
  * Entity class for the Certificate Verifiable Credential.
@@ -36,7 +31,6 @@ import java.time.Instant;
 @Setter
 @ToString
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Table(name = "certificate_vc")
 public class CertificateVc extends BaseEntity implements Serializable {
     @Id

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/E2E.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/E2E.java
@@ -18,10 +18,8 @@ package org.omnione.did.base.db.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.io.Serializable;
-import java.time.Instant;
 
 /**
  * Entity class for the e2e table.
@@ -35,7 +33,6 @@ import java.time.Instant;
 @ToString
 @Entity
 @Table(name = "e2e")
-@EntityListeners(AuditingEntityListener.class)
 public class E2E extends BaseEntity implements Serializable {
     @Id
     @Column(name = "id", nullable = false)

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/RevokeVc.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/RevokeVc.java
@@ -19,10 +19,9 @@ package org.omnione.did.base.db.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.omnione.did.data.model.enums.vc.VcStatus;
-import org.springframework.data.annotation.CreatedDate;
 
 import java.io.Serializable;
-import java.time.Instant;
+
 
 /**
  * Entity class for the revoke_vc table.

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/SubTransaction.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/SubTransaction.java
@@ -22,7 +22,6 @@ import org.omnione.did.base.db.constant.SubTransactionStatus;
 import org.omnione.did.base.db.constant.SubTransactionType;
 
 import java.io.Serializable;
-import java.time.Instant;
 
 /**
  * Entity class for the sub_transaction table.

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/Transaction.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/Transaction.java
@@ -20,8 +20,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.omnione.did.base.db.constant.TransactionStatus;
 import org.omnione.did.base.db.constant.TransactionType;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.io.Serializable;
 import java.time.Instant;
@@ -39,7 +37,6 @@ import java.util.List;
 @ToString
 @Entity
 @Table(name = "transaction")
-@EntityListeners(AuditingEntityListener.class)
 public class Transaction extends BaseEntity implements Serializable {
     @Id
     @Column(name = "id", nullable = false)

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/User.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/User.java
@@ -20,7 +20,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.io.Serializable;
-import java.time.Instant;
 
 /**
  * Entity class for the user table.

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/Vc.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/Vc.java
@@ -18,11 +18,6 @@ package org.omnione.did.base.db.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.antlr.v4.runtime.misc.NotNull;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.io.Serializable;
 import java.time.Instant;

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/VcOffer.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/VcOffer.java
@@ -19,7 +19,6 @@ package org.omnione.did.base.db.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.omnione.did.base.datamodel.enums.OfferType;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.io.Serializable;
 import java.time.Instant;
@@ -36,7 +35,6 @@ import java.time.Instant;
 @ToString
 @Entity
 @Table(name = "vc_offer")
-@EntityListeners(AuditingEntityListener.class)
 public class VcOffer extends BaseEntity implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/VcProfile.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/db/domain/VcProfile.java
@@ -18,10 +18,8 @@ package org.omnione.did.base.db.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.io.Serializable;
-import java.util.List;
 
 /**
  * Entity class for the vc_profile table.

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/BaseEntityTest.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/BaseEntityTest.java
@@ -1,0 +1,37 @@
+package org.omnione.did.base.db.domain;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.omnione.did.base.config.JpaConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@TestPropertySource(properties = {
+        "spring.datasource.url = jdbc:h2:mem:test",
+        "spring.datasource.driverClassName = org.h2.Driver",
+        "spring.datasource.username = sa",
+        "spring.datasource.password = ",
+})
+@DataJpaTest
+@Import(JpaConfig.class)
+class BaseEntityTest {
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Test
+    void shouldSetAuditingFieldsOnPersist() {
+
+        CertificateVc auditableEntity = CertificateVc.builder().vc("").build();
+        assertNull(auditableEntity.getUpdatedAt());
+
+        entityManager.persist(auditableEntity);
+        assertNotNull(auditableEntity.getUpdatedAt());
+    }
+}

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/BaseEntityTest.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/BaseEntityTest.java
@@ -1,7 +1,6 @@
 package org.omnione.did.base.db.domain;
 
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.omnione.did.base.config.JpaConfig;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,9 +28,11 @@ class BaseEntityTest {
     void shouldSetAuditingFieldsOnPersist() {
 
         CertificateVc auditableEntity = CertificateVc.builder().vc("").build();
+        assertNull(auditableEntity.getCreatedAt());
         assertNull(auditableEntity.getUpdatedAt());
 
         entityManager.persist(auditableEntity);
+        assertNotNull(auditableEntity.getCreatedAt());
         assertNotNull(auditableEntity.getUpdatedAt());
     }
 }


### PR DESCRIPTION
JPA Auditing Functionality

## Description
Ensured AuditingEntityListener is properly configured and functioning.
Removed unnecessary AuditingEntityListener declarations from several entities.
Added tests to verify auditing fields (@CreatedDate, @LastModifiedDate) work as expected.

## Changes
- Can I add 'H2' dependencies


## Additional Comments (Optional)
The createdAt field in BaseEntity.class is currently being assigned Instant.now(), even though it is also annotated with @CreatedDate. This prevents the JPA auditing mechanism from being utilized.

Should I continue using the Instant.now() assignment, or is it better to rely solely on @CreatedDate for automatic population of the field?


