### PR TITLE
Replace status code literals with HttpStatus constants in GlobalControllerAdvice

### DIFF
--- a/source/did-issuer-server/src/main/java/org/omnione/did/base/controller/GlobalControllerAdvice.java
+++ b/source/did-issuer-server/src/main/java/org/omnione/did/base/controller/GlobalControllerAdvice.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.omnione.did.base.exception.ErrorCode;
 import org.omnione.did.base.exception.OpenDidException;
 import org.omnione.did.base.response.ErrorResponse;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -41,11 +42,14 @@ import java.util.stream.Collectors;
 @RestControllerAdvice(basePackages = {"org.omnione.did"})
 public class GlobalControllerAdvice {
 
+    private static final String UNKNOWN_ERROR_CODE = "9999";
+
     @ExceptionHandler(OpenDidException.class)
     public ResponseEntity<ErrorResponse> handleTasException(OpenDidException ex) {
+
         if (ex.getErrorResponse() != null) {
             ex.printStackTrace();
-            return new ResponseEntity<>(ex.getErrorResponse(), HttpStatus.valueOf(400));
+            return new ResponseEntity<>(ex.getErrorResponse(), HttpStatus.BAD_REQUEST);
         }
 
         log.error("Error", ex);
@@ -56,34 +60,31 @@ public class GlobalControllerAdvice {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
-        int httpStatus = 500;
 
         String errorMessages = ex.getBindingResult()
                 .getFieldErrors()
                 .stream()
-                .map(error -> error.getDefaultMessage())
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .collect(Collectors.joining("; "));
 
         log.error("Error", ex);
-
-        ErrorResponse errorResponse = new ErrorResponse("9999", errorMessages);
-        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(httpStatus));
+        ErrorResponse errorResponse = new ErrorResponse(UNKNOWN_ERROR_CODE, errorMessages);
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(HttpMessageNotReadableException ex) {
-        log.error("Error", ex);
 
+        log.error("Error", ex);
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.REQUEST_BODY_UNREADABLE);
-        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(500));
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleValidationException(Exception ex) {
-        ErrorResponse errorResponse = new ErrorResponse("500", ex.getMessage());
 
-        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(500));
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        ErrorResponse errorResponse = new ErrorResponse(String.valueOf(httpStatus.value()), ex.getMessage());
+        return new ResponseEntity<>(errorResponse, httpStatus);
     }
-
-
 }

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/controller/GlobalControllerAdviceTest.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/controller/GlobalControllerAdviceTest.java
@@ -1,0 +1,76 @@
+package org.omnione.did.base.controller;
+
+import org.junit.jupiter.api.Test;
+import org.omnione.did.base.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+/**
+ * Check the behavior of {@link GlobalControllerAdvice}
+ * @author birariro
+ */
+@WithMockUser
+@WebMvcTest(controllers = GlobalControllerAdviceTestController.class)
+@Import(GlobalControllerAdvice.class)
+class GlobalControllerAdviceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void should_badRequest_when_hasErrorResponseByOpenDidException() throws Exception {
+        mockMvc.perform(post("/test/exception/OpenDidException/ErrorResponse")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").isNotEmpty())
+                .andExpect(jsonPath("$.description").isNotEmpty());
+    }
+
+    @Test
+    void should_internalServerError_when_emptyErrorResponseByOpenDidException() throws Exception {
+        mockMvc.perform(post("/test/exception/OpenDidException/ErrorCode")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(ErrorCode.UNKNOWN_SERVER_ERROR.getCode()))
+                .andExpect(jsonPath("$.description").value(ErrorCode.UNKNOWN_SERVER_ERROR.getMessage()));
+    }
+
+    @Test
+    void should_internalServerError_when_MethodArgumentNotValidException() throws Exception {
+        int unknown_error_code = 9999;
+        mockMvc.perform(post("/test/exception/MethodArgumentNotValidException")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(unknown_error_code))
+                .andExpect(jsonPath("$.description").isNotEmpty());
+    }
+
+    @Test
+    void should_internalServerError_when_HttpMessageNotReadableException() throws Exception {
+        mockMvc.perform(post("/test/exception/HttpMessageNotReadableException")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(ErrorCode.REQUEST_BODY_UNREADABLE.getCode()))
+                .andExpect(jsonPath("$.description").value(ErrorCode.REQUEST_BODY_UNREADABLE.getMessage()));
+    }
+
+    @Test
+    void should_internalServerError_when_GenericException() throws Exception {
+        mockMvc.perform(post("/test/exception/Exception")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(HttpStatus.INTERNAL_SERVER_ERROR.value()))
+                .andExpect(jsonPath("$.description").isNotEmpty());
+    }
+}
+

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/controller/GlobalControllerAdviceTestController.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/controller/GlobalControllerAdviceTestController.java
@@ -1,0 +1,59 @@
+package org.omnione.did.base.controller;
+
+import org.omnione.did.base.exception.ErrorCode;
+import org.omnione.did.base.exception.OpenDidException;
+import org.omnione.did.base.response.ErrorResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * something for {@link GlobalControllerAdviceTest}
+ * @author birariro
+ */
+@RestController
+class GlobalControllerAdviceTestController {
+
+    @PostMapping("/test/exception/OpenDidException/ErrorResponse")
+    public void throwOpenDidException() {
+        throw new OpenDidException(new ErrorResponse("999", "message"));
+    }
+
+    @PostMapping("/test/exception/OpenDidException/ErrorCode")
+    public void throwOpenDidExceptionAndErrorCode() {
+        throw new OpenDidException(ErrorCode.UNKNOWN_SERVER_ERROR);
+    }
+
+    @PostMapping("/test/exception/MethodArgumentNotValidException")
+    public void throwMethodArgumentNotValidException() throws MethodArgumentNotValidException {
+
+        FieldError fieldError = new FieldError("dummyRequest", "name", "Name must not be blank");
+        BindingResult bindingResult = new BeanPropertyBindingResult(Map.of(), "dummyRequest");
+        bindingResult.addError(fieldError);
+
+        throw new MethodArgumentNotValidException(
+                new MethodParameter(this.getClass().getDeclaredMethods()[0], -1),
+                bindingResult
+        );
+    }
+
+    @PostMapping("/test/exception/HttpMessageNotReadableException")
+    public void throwHttpMessageNotReadableException() {
+        HttpInputMessage dummyInputMessage = new MockHttpInputMessage("dummy body".getBytes());
+        throw new HttpMessageNotReadableException("json error", dummyInputMessage);
+    }
+
+    @PostMapping("/test/exception/Exception")
+    public void throwRuntimeException() {
+        throw new RuntimeException("Generic exception");
+    }
+}


### PR DESCRIPTION
Replace status code literals with HttpStatus constants in GlobalControllerAdvice

## Description
Replaced hardcoded HTTP status code literals (`400`, `500`, etc.) in `GlobalControllerAdvice` with corresponding `HttpStatus` enum constants such as `HttpStatus.BAD_REQUEST` and `HttpStatus.INTERNAL_SERVER_ERROR`.