### PR TITLE
Migrate from Querydsl 5.0.0 to OpenFeign Querydsl 6.11 due to project deprecation

### DIFF
--- a/source/did-issuer-server/build.gradle
+++ b/source/did-issuer-server/build.gradle
@@ -57,8 +57,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.34'
 
     // Query DSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.11'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.11:jpa'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 

--- a/source/did-issuer-server/src/test/java/org/omnione/did/InMemoryDataJpaTest.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/InMemoryDataJpaTest.java
@@ -1,0 +1,40 @@
+package org.omnione.did;
+
+import org.omnione.did.base.config.JpaConfig;
+import org.omnione.did.base.config.QuerydslConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A composed annotation used for integration testing of JPA-based repositories
+ * in an in-memory database environment. This annotation is a specialized form
+ * of {@code @DataJpaTest}, and it configures the database to use an H2 in-memory
+ * JDBC connection with predefined settings for testing.
+ * <p>
+ * It automatically includes Spring Data JPA configurations and additional
+ * configurations related to auditing and QueryDSL support by importing
+ * {@code JpaConfig} and {@code QuerydslConfig} classes.
+ * <p>
+ * The annotation is primarily used to simplify the setup needed for testing
+ * persistence layers by preconfiguring the necessary test environment.
+ *
+ * @author birariro
+ */
+@TestPropertySource(properties = {
+        "spring.datasource.url = jdbc:h2:mem:test",
+        "spring.datasource.driverClassName = org.h2.Driver",
+        "spring.datasource.username = sa",
+        "spring.datasource.password = ",
+})
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class})
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InMemoryDataJpaTest {
+}

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/config/QuerydslConfigTest.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/config/QuerydslConfigTest.java
@@ -5,11 +5,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
+import org.omnione.did.InMemoryDataJpaTest;
 import org.omnione.did.base.db.domain.TestSimpleAuditingEntity;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,14 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author birariro
  */
-@TestPropertySource(properties = {
-        "spring.datasource.url = jdbc:h2:mem:test",
-        "spring.datasource.driverClassName = org.h2.Driver",
-        "spring.datasource.username = sa",
-        "spring.datasource.password = ",
-})
-@DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@InMemoryDataJpaTest
 class QuerydslConfigTest {
 
     @Autowired

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/config/QuerydslConfigTest.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/config/QuerydslConfigTest.java
@@ -1,0 +1,50 @@
+package org.omnione.did.base.config;
+
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.omnione.did.base.db.domain.TestSimpleAuditingEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Check the action of "OpenFeign/querydsl"
+ *
+ * @author birariro
+ */
+@TestPropertySource(properties = {
+        "spring.datasource.url = jdbc:h2:mem:test",
+        "spring.datasource.driverClassName = org.h2.Driver",
+        "spring.datasource.username = sa",
+        "spring.datasource.password = ",
+})
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class})
+class QuerydslConfigTest {
+
+    @Autowired
+    private JPAQueryFactory queryFactory;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void shouldSameEntityManagerAndJPAQueryFactory() {
+
+        entityManager.persist(new TestSimpleAuditingEntity("Alice"));
+        entityManager.persist(new TestSimpleAuditingEntity("Bob"));
+        entityManager.persist(new TestSimpleAuditingEntity("Charlie"));
+
+        PathBuilder<TestSimpleAuditingEntity> entity = new PathBuilder<>(TestSimpleAuditingEntity.class, "testSimpleAuditingEntity");
+
+        Long countByEntityManager = (Long) entityManager.createQuery("select count(u.id) from TestSimpleAuditingEntity u").getSingleResult();
+        Long countByQueryDsl = queryFactory.select(entity.count()).from(entity).fetchOne();
+        assertThat(countByQueryDsl).isEqualTo(countByEntityManager);
+    }
+}

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/BaseEntityTest.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/BaseEntityTest.java
@@ -1,10 +1,10 @@
 package org.omnione.did.base.db.domain;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.omnione.did.base.config.JpaConfig;
 import org.omnione.did.base.config.QuerydslConfig;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
@@ -12,6 +12,12 @@ import org.springframework.test.context.TestPropertySource;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+/**
+ * The BaseEntityTest class contains unit tests for verifying the behavior of
+ * entity auditing fields such as `createdAt` and `updatedAt` during persistence.
+ *
+ * @author birariro
+ */
 @TestPropertySource(properties = {
         "spring.datasource.url = jdbc:h2:mem:test",
         "spring.datasource.driverClassName = org.h2.Driver",
@@ -22,18 +28,18 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @Import({JpaConfig.class, QuerydslConfig.class})
 class BaseEntityTest {
 
-    @Autowired
+    @PersistenceContext
     EntityManager entityManager;
 
     @Test
     void shouldSetAuditingFieldsOnPersist() {
 
-        CertificateVc auditableEntity = CertificateVc.builder().vc("").build();
-        assertNull(auditableEntity.getCreatedAt());
-        assertNull(auditableEntity.getUpdatedAt());
+        TestSimpleAuditingEntity testSimpleAuditingEntity = new TestSimpleAuditingEntity();
+        assertNull(testSimpleAuditingEntity.getCreatedAt());
+        assertNull(testSimpleAuditingEntity.getUpdatedAt());
 
-        entityManager.persist(auditableEntity);
-        assertNotNull(auditableEntity.getCreatedAt());
-        assertNotNull(auditableEntity.getUpdatedAt());
+        entityManager.persist(testSimpleAuditingEntity);
+        assertNotNull(testSimpleAuditingEntity.getCreatedAt());
+        assertNotNull(testSimpleAuditingEntity.getUpdatedAt());
     }
 }

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/BaseEntityTest.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/BaseEntityTest.java
@@ -3,11 +3,7 @@ package org.omnione.did.base.db.domain;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
-import org.omnione.did.base.config.JpaConfig;
-import org.omnione.did.base.config.QuerydslConfig;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.TestPropertySource;
+import org.omnione.did.InMemoryDataJpaTest;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -18,14 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  *
  * @author birariro
  */
-@TestPropertySource(properties = {
-        "spring.datasource.url = jdbc:h2:mem:test",
-        "spring.datasource.driverClassName = org.h2.Driver",
-        "spring.datasource.username = sa",
-        "spring.datasource.password = ",
-})
-@DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@InMemoryDataJpaTest
 class BaseEntityTest {
 
     @PersistenceContext

--- a/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/TestSimpleAuditingEntity.java
+++ b/source/did-issuer-server/src/test/java/org/omnione/did/base/db/domain/TestSimpleAuditingEntity.java
@@ -1,0 +1,59 @@
+package org.omnione.did.base.db.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+/**
+ * simple entity that demonstrates auditing for testing
+ *
+ * @author birariro
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class TestSimpleAuditingEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", insertable = false)
+    private Instant updatedAt;
+
+    public TestSimpleAuditingEntity() {
+    }
+
+    public TestSimpleAuditingEntity(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}


### PR DESCRIPTION
## Description
You are currently using Querysl 5.0.0 and you must use the latest version

### Project Deprecation
The original Querydsl project is no longer actively maintained. No security patches or feature updates have been released in years, and the community has effectively moved to the OpenFeign Querydsl fork, which is now the actively maintained and recommended version.

### Security Vulnerability
Querydsl versions 5.1.0 and below are vulnerable to CVE-2024-49203, which allows potential SQL/HQL injection through unsafe usage of methods like orderBy() when passing user input directly.
This issue has been fixed in the OpenFeign fork of Querydsl (version 6.10.1 and above).
