### PR TITLE
feat : Fix vulnerabilities detected by GitHub Dependabot

### DIFF
--- a/source/did-issuer-admin/frontend/package-lock.json
+++ b/source/did-issuer-admin/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-quill-new": "^3.3.3",
-        "react-router": "^7",
+        "react-router": "^7.18.2",
         "styled-components": "^6.1.15"
       },
       "devDependencies": {
@@ -3347,9 +3347,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/source/did-issuer-admin/frontend/package.json
+++ b/source/did-issuer-admin/frontend/package.json
@@ -29,7 +29,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-quill-new": "^3.3.3",
-    "react-router": "^7",
+    "react-router": "^7.18.2",
     "styled-components": "^6.1.15"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This pull request addresses security vulnerabilities detected by Dependabot in the project dependencies. The `react-router` package version has been updated from `7.16.0` to `7.18.2` to resolve these issues.

Note: react-router cannot be bumped to `8.x` (dependabot's original suggestion in #50) because `@toolpad/core` still requires `^7` — doing so breaks the build. Alert `#42` (RSC mode CSRF) requires `8.x` and is therefore not resolved here; alerts `#41`, `#43`, `#44`, `#45` are resolved.

## Changes

* Updated the `react-router` package version from `7.16.0` to `7.18.2` to fix security vulnerabilities reported by Dependabot.